### PR TITLE
Make menu bar background gray not white #4148

### DIFF
--- a/packages/application/style/index.css
+++ b/packages/application/style/index.css
@@ -35,9 +35,12 @@ body {
 
 #jp-top-panel {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color0);
-  background: var(--jp-layout-color1);
   display: flex;
   min-height: var(--jp-private-menubar-height);
+}
+
+#jp-top-panel, #jp-MainMenu {
+  background: var(--jp-layout-color2);
 }
 
 #jp-bottom-panel {


### PR DESCRIPTION
This addressed #4148 issue - menu (navigation) bar inconsistent background color and makes menu look more natural and less intrusive.